### PR TITLE
Added "views_path" property in Configuration to customize views direc…

### DIFF
--- a/src/endpoint/authentication.ts
+++ b/src/endpoint/authentication.ts
@@ -1,7 +1,6 @@
 import * as functions from "firebase-functions";
 import * as admin from "firebase-admin";
 import * as express from "express";
-import * as path from "path";
 import {RequestWrapper} from "../models";
 import {Configuration, Crypto, Navigation} from "../utils";
 
@@ -10,7 +9,7 @@ class AuthenticationApp {
   static create(providerName: string): express.Express {
     const authenticationApp = express()
 
-    authenticationApp.set("views", path.join(__dirname, "../../views"))
+    authenticationApp.set("views", Configuration.instance.view_path)
 
     authenticationApp.get("/", (req, resp) => {
       const request = new RequestWrapper(req)

--- a/src/endpoint/authentication.ts
+++ b/src/endpoint/authentication.ts
@@ -34,6 +34,7 @@ class AuthenticationApp {
           if (idToken.aud === process.env.GCLOUD_PROJECT) {
             const encryptedUserId = Crypto.encrypt(idToken.sub)
             Navigation.redirect(resp, "/authorize/consent", {"auth_token": encryptedAuthToken, "user_id": encryptedUserId})
+            return;
           }
         } catch(e) {
           console.log("e", e)

--- a/src/endpoint/views/default_consent_view_template.ts
+++ b/src/endpoint/views/default_consent_view_template.ts
@@ -1,12 +1,13 @@
 import * as fs from "fs";
 import * as path from "path";
 import {ConsentViewTemplate} from "./consent_view_template";
+import { Configuration } from "../../utils";
 
 export class DefaultConsentViewTemplate implements ConsentViewTemplate {
 
   public provide(): Promise<string> {
     return new Promise<string>((resolve, reject) => {
-      fs.readFile(path.join(__dirname, "../../../views/consent.ejs"), "utf8", (err, data) => {
+      fs.readFile(path.join(Configuration.instance.view_path, "consent.ejs"), "utf8", (err, data) => {
         if (err) {
           console.error(err)
           reject(err)

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -1,5 +1,7 @@
 import {ConsentViewTemplate} from "../endpoint/views/consent_view_template";
 import {DefaultConsentViewTemplate} from "../endpoint/views/default_consent_view_template";
+import * as fs from "fs";
+import * as path from "path";
 
 export interface ConfigurationParameters {
   crypto_auth_token_secret_key_32: string
@@ -7,6 +9,7 @@ export interface ConfigurationParameters {
   views_authentication_path?: string
   views_consent_template?: ConsentViewTemplate
   tokens_expires_in?: Map<string, number>
+  view_path: string
 }
 
 export class Configuration {
@@ -17,6 +20,7 @@ export class Configuration {
   private _project_apikey: string | undefined
   private _view_consent_template: ConsentViewTemplate | undefined
   private _tokens_expires_in: Map<string, number> | undefined
+  private _view_path: string
 
   private constructor() {
   }
@@ -33,6 +37,7 @@ export class Configuration {
     this.instance._project_apikey = params.project_api_key
     this.instance._view_consent_template = params.views_consent_template
     this.instance._tokens_expires_in = params.tokens_expires_in
+    this.instance._view_path = params.view_path
   }
 
   public get crypto_auth_token_secret_key_32(): string {
@@ -70,6 +75,14 @@ export class Configuration {
       result.set("client_credentials", 86400)
       result.set("refresh_token", 86400)
       return result
+    }
+  }
+
+  get view_path(): string {
+    if(this._view_path && fs.existsSync(this._view_path)) {
+      return this._view_path;
+    } else {
+      return path.join(__dirname, '../../views');
     }
   }
 

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -9,7 +9,7 @@ export interface ConfigurationParameters {
   views_authentication_path?: string
   views_consent_template?: ConsentViewTemplate
   tokens_expires_in?: Map<string, number>
-  view_path: string
+  view_path?: string
 }
 
 export class Configuration {
@@ -20,7 +20,7 @@ export class Configuration {
   private _project_apikey: string | undefined
   private _view_consent_template: ConsentViewTemplate | undefined
   private _tokens_expires_in: Map<string, number> | undefined
-  private _view_path: string
+  private _view_path: string | undefined
 
   private constructor() {
   }

--- a/src/utils/configuration.ts
+++ b/src/utils/configuration.ts
@@ -6,7 +6,6 @@ import * as path from "path";
 export interface ConfigurationParameters {
   crypto_auth_token_secret_key_32: string
   project_api_key: string
-  views_authentication_path?: string
   views_consent_template?: ConsentViewTemplate
   tokens_expires_in?: Map<string, number>
   view_path?: string


### PR DESCRIPTION
This PR added a new configuration property "views_path" allow to define a different views directory to customize the `authentication.ejs` as well as the `consent.ejs` templates.

```ts
Configuration.init({
  crypto_auth_token_secret_key_32: '[...]',
  project_api_key: '[...]',
  view_path: path.join(__dirname, '../../views')
});
```

Would really appreciate this to be part of the project.
Thank you